### PR TITLE
Alternate ways to upgrade shell

### DIFF
--- a/forward-shell.py
+++ b/forward-shell.py
@@ -76,7 +76,7 @@ class WebShell(object):
 
     def UpgradeShell(self):
         # upgrade shell
-        UpgradeShell = """python3 -c 'import pty; pty.spawn("/bin/bash")'"""
+        UpgradeShell = """python3 -c 'import pty; pty.spawn("/bin/bash")' || python -c 'import pty; pty.spawn("/bin/bash")' || script -qc /bin/bash /dev/null"""
         self.WriteCmd(UpgradeShell)
 
 prompt = "Please Subscribe> "


### PR DESCRIPTION
Thanks for the script.
This is just a small contribution to consider other ways to upgrade the shell in case `python3` doesn't exist. I tested it in Pressed and it worked.